### PR TITLE
feat: generate a business description from a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ An agentic system that uses LLMs and generative AI models to create short video 
 ## Features
 
 - **Agentic Workflow**: Uses LangGraph for orchestrated ad generation
+- **Website Analysis**: Automatically analyzes business websites to extract company info
+- **Intelligent Business Descriptions**: Generates rich business profiles from web content
 - **Provider Agnostic**: Abstractions for LLM, video, audio, and music providers
 - **Human Review Points**: Strategic approval points in the workflow
 - **Markdown Output**: Generated concepts and plans saved as markdown files
+- **Flexible Input**: Accepts either website URLs or direct business descriptions
 - **CLI Interface**: Easy-to-use command line interface
 
 ## Quick Start
@@ -27,9 +30,51 @@ An agentic system that uses LLMs and generative AI models to create short video 
 
 3. **Generate an ad:**
 
+   **From a website URL:**
+
+   ```bash
+   uv run adgen -u https://your-business-website.com
+   ```
+
+   **From a business description:**
+
    ```bash
    uv run adgen -b "We sell eco-friendly water bottles for athletes"
    ```
+
+   **Interactive mode:**
+
+   ```bash
+   uv run adgen
+   # Follow prompts to choose URL or description input
+   ```
+
+## How It Works
+
+AdGen supports two input methods:
+
+### URL Input (Recommended)
+
+1. **Web Scraping**: Extracts content from the business website
+2. **Business Analysis**: AI analyzes the content to understand:
+   - Company overview and mission
+   - Branding style and personality
+   - Products and services
+   - Target customers and market positioning
+3. **Rich Description**: Generates a comprehensive business profile
+4. **Ad Creation**: Uses the business profile to create targeted ads
+
+### Direct Description Input
+
+1. **Business Description**: User provides direct business description
+2. **Ad Creation**: Immediately proceeds to ad concept generation
+
+Both paths then follow the same workflow:
+
+- **Concept Generation**: Creates ad strategy and messaging
+- **Human Review**: Approval checkpoint for concept
+- **Script & Visual Planning**: Generates narration and visual elements
+- **Output**: Saves all components as organized markdown files
 
 ## Configuration
 
@@ -38,6 +83,7 @@ Edit `config.yaml` to customize:
 - Provider preferences (OpenAI, Anthropic, etc.)
 - Video duration and quality settings
 - Review and approval settings
+- Web scraping preferences
 
 ## Project Structure
 
@@ -55,6 +101,8 @@ adgen/
 Currently implemented:
 
 - ✅ Project structure and configuration
+- ✅ Website content extraction and analysis
+- ✅ AI-powered business description generation
 - ✅ Provider abstractions with mock implementations
 - ✅ LangGraph workflow for ad concept generation
 - ✅ Structured LLM output

--- a/adgen/models/ad.py
+++ b/adgen/models/ad.py
@@ -47,8 +47,12 @@ class AdAssets(BaseModel):
 class AdProject(BaseModel):
     """Complete advertisement project containing all components."""
 
-    # Input
-    business_description: str
+    # Input - either URL or direct business description
+    source_url: str | None = None
+    business_description: str | None = None
+
+    # Intermediate content (for URL input)
+    web_content_markdown: str | None = None
 
     # Generated content
     concept: AdConcept | None = None
@@ -59,4 +63,6 @@ class AdProject(BaseModel):
     # Metadata
     project_id: str
     created_at: str
-    status: str = "created"  # created, concept_generated, script_generated, etc.
+    status: str = (
+        "created"  # created, web_scraped, business_analyzed, concept_generated, etc.
+    )

--- a/adgen/utils/markdown.py
+++ b/adgen/utils/markdown.py
@@ -1,7 +1,48 @@
 from datetime import datetime
 from pathlib import Path
 
+import html2text
+import httpx
+
 from adgen.models.ad import AdConcept, AdProject, AdScript, VisualPlan
+
+
+async def get_markdown_from_web_page(
+    url: str, ignore_links: bool = True, ignore_images: bool = True, timeout: int = 20
+) -> str | None:
+    """Convert HTML from a URL to nicely formatted markdown (async version).
+
+    Args:
+        url: The URL to fetch and convert
+        ignore_links: If True, don't include links in the markdown output
+        ignore_images: If True, don't include images in the markdown output
+        timeout: Request timeout in seconds
+
+    Returns:
+        Markdown string or None if conversion failed
+    """
+    # Fetch the HTML with proper headers using httpx
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+    }
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(url, headers=headers)
+        response.raise_for_status()
+
+        # Configure the converter
+        h = html2text.HTML2Text()
+        h.ignore_links = ignore_links
+        h.ignore_images = ignore_images
+        h.body_width = 0  # Don't wrap lines
+        h.unicode_snob = True
+        h.bypass_tables = False
+        h.ignore_emphasis = False  # Keep bold/italic formatting
+        h.mark_code = True  # Mark code blocks
+
+        # Convert and clean up
+        markdown = h.handle(response.text)
+        return markdown.strip()
 
 
 def generate_concept_markdown(concept: AdConcept, project_id: str) -> str:
@@ -89,7 +130,16 @@ def generate_full_project_markdown(project: AdProject) -> str:
 **Created**: {project.created_at}
 **Status**: {project.status}
 
-## Business Description
+"""
+
+    if project.source_url:
+        content += f"""## Source URL
+{project.source_url}
+
+"""
+
+    if project.business_description:
+        content += f"""## Business Description
 {project.business_description}
 
 """

--- a/adgen/workflows/ad_generation.py
+++ b/adgen/workflows/ad_generation.py
@@ -7,6 +7,7 @@ from langgraph.graph import END, StateGraph
 
 from adgen.models.ad import AdConcept, AdProject, AdScript, VisualPlan
 from adgen.utils.config import Config, get_api_key
+from adgen.utils.markdown import get_markdown_from_web_page
 
 
 class AdGenerationState(dict[str, Any]):
@@ -36,6 +37,108 @@ def create_llm(config: Config) -> BaseChatModel:
         return ChatAnthropic(api_key=api_key, model=model, temperature=temperature)
     else:
         raise ValueError(f"Unsupported LLM provider: {provider}")
+
+
+async def scrape_web_content_node(state: AdGenerationState) -> AdGenerationState:
+    """Extract markdown content from the provided URL."""
+    if not state["project"].source_url:
+        # Skip if no URL provided
+        return state
+
+    print(f"Scraping content from: {state['project'].source_url}")
+
+    try:
+        markdown_content = await get_markdown_from_web_page(state["project"].source_url)
+        state["project"].web_content_markdown = markdown_content
+        state["project"].status = "web_scraped"
+        print(f"Successfully scraped {len(markdown_content)} characters of content")
+    except Exception as e:
+        print(f"Error scraping web content: {e}")
+        # Continue with empty content for now
+        state["project"].web_content_markdown = ""
+        state["project"].status = "web_scrape_failed"
+
+    return state
+
+
+async def generate_business_description_node(
+    state: AdGenerationState,
+) -> AdGenerationState:
+    """Generate a business description from scraped web content."""
+    if not state["project"].web_content_markdown:
+        # Skip if no web content
+        return state
+
+    llm = create_llm(state["config"])
+
+    prompt = f"""
+    You are a business analyst. Analyze the following website content and create a comprehensive business description that will be used for creating a video advertisement.
+
+    Website Content (Markdown):
+    {state["project"].web_content_markdown[:8000]}  # Limit to avoid token limits
+
+    Please create a detailed business description that includes:
+
+    ## Company Overview
+    - What kind of business this is
+    - Their mission and values
+    - Their unique value proposition
+
+    ## Branding & Style
+    - Brand personality and tone
+    - Visual style preferences (if evident)
+    - Brand positioning
+
+    ## Products & Services
+    - Main product categories
+    - Key products or services
+    - Target market for each
+
+    ## Customer Focus
+    - Primary customer demographics
+    - Customer pain points they solve
+    - Customer success stories or testimonials (if mentioned)
+
+    Format this as a well-structured markdown document that captures the essence of the business for advertising purposes. Focus on details that would be relevant for creating a compelling video advertisement.
+    """
+
+    print("Generating business description from web content...")
+
+    try:
+        description = await llm.ainvoke(prompt)
+        state["project"].business_description = description.content
+        state["project"].status = "business_analyzed"
+        print(f"Generated business description: {len(description.content)} characters")
+    except Exception as e:
+        print(f"Error generating business description: {e}")
+        # Fallback to truncated web content
+        state["project"].business_description = state["project"].web_content_markdown[
+            :2000
+        ]
+        state["project"].status = "business_analysis_failed"
+
+    return state
+
+
+def should_scrape_web_content(state: AdGenerationState) -> str:
+    """Decide whether to scrape web content or go directly to concept generation."""
+    if state["project"].source_url:
+        return "scrape_web"
+    elif state["project"].business_description:
+        return "generate_concept"
+    else:
+        raise ValueError("Either source_url or business_description must be provided")
+
+
+def should_generate_business_description(state: AdGenerationState) -> str:
+    """Decide whether to generate business description from web content."""
+    if (
+        state["project"].web_content_markdown
+        and state["project"].status == "web_scraped"
+    ):
+        return "generate_business_description"
+    else:
+        return "generate_concept"
 
 
 async def generate_concept_node(state: AdGenerationState) -> AdGenerationState:
@@ -169,13 +272,40 @@ def create_ad_generation_workflow(_config: Config) -> StateGraph:
     workflow = StateGraph(AdGenerationState)
 
     # Add nodes
+    workflow.add_node("scrape_web_content", scrape_web_content_node)
+    workflow.add_node(
+        "generate_business_description", generate_business_description_node
+    )
     workflow.add_node("generate_concept", generate_concept_node)
     workflow.add_node("review_concept", review_concept_node)
     workflow.add_node("generate_script", generate_script_node)
     workflow.add_node("generate_visual_plan", generate_visual_plan_node)
 
-    # Add edges
-    workflow.set_entry_point("generate_concept")
+    # Set entry point and routing
+    workflow.set_entry_point("route_input")
+    workflow.add_node("route_input", lambda state: state)  # Dummy node for routing
+
+    # Route based on input type
+    workflow.add_conditional_edges(
+        "route_input",
+        should_scrape_web_content,
+        {"scrape_web": "scrape_web_content", "generate_concept": "generate_concept"},
+    )
+
+    # Web scraping path
+    workflow.add_conditional_edges(
+        "scrape_web_content",
+        should_generate_business_description,
+        {
+            "generate_business_description": "generate_business_description",
+            "generate_concept": "generate_concept",
+        },
+    )
+
+    # Business description generation to concept
+    workflow.add_edge("generate_business_description", "generate_concept")
+
+    # Concept review and continuation
     workflow.add_edge("generate_concept", "review_concept")
     workflow.add_conditional_edges(
         "review_concept",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "moviepy>=1.0.3",
     "langchain-openai>=0.3.24",
     "langchain-anthropic>=0.3.15",
+    "httpx>=0.27.0",
+    "html2text>=2024.2.26",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,8 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "click" },
+    { name = "html2text" },
+    { name = "httpx" },
     { name = "instructor" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
@@ -39,6 +41,8 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.34.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
     { name = "click", specifier = ">=8.1.0" },
+    { name = "html2text", specifier = ">=2024.2.26" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "instructor", specifier = ">=1.3.0" },
     { name = "langchain", specifier = ">=0.3.0" },
     { name = "langchain-anthropic", specifier = ">=0.3.15" },
@@ -560,6 +564,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+]
+
+[[package]]
+name = "html2text"
+version = "2025.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview

This PR updates the workflow to take a URL as its sole input. We scrape the page at that URL, convert to markdown, then generate a business description from that markdown. This then serves as the foundation for generating the ad concept and script.
